### PR TITLE
Use mail package in ExtractPlaintextBody

### DIFF
--- a/server/imap/append.go
+++ b/server/imap/append.go
@@ -120,7 +120,7 @@ func (s *IMAPSession) appendSingle(ctx context.Context, mbox *db.Mailbox, messag
 
 	bodyStructure := imapserver.ExtractBodyStructure(bytes.NewReader(buf.Bytes()))
 
-	plaintextBody, err := helpers.ExtractPlaintextBody(messageContent, buf, true)
+	plaintextBody, err := helpers.ExtractPlaintextBody(messageContent)
 	if err != nil {
 		log.Printf("Failed to extract plaintext body: %v", err)
 		return nil, consts.ErrMalformedMessage

--- a/server/lmtp/session.go
+++ b/server/lmtp/session.go
@@ -97,7 +97,7 @@ func (s *LMTPSession) Data(r io.Reader) error {
 
 	bodyStructure := imapserver.ExtractBodyStructure(bytes.NewReader(buf.Bytes()))
 
-	plaintextBody, err := helpers.ExtractPlaintextBody(messageContent, &buf, true)
+	plaintextBody, err := helpers.ExtractPlaintextBody(messageContent)
 	if err != nil {
 		log.Printf("Failed to extract plaintext body: %v", err)
 		return &smtp.SMTPError{


### PR DESCRIPTION
- Text attachments are no longer handled like inline parts.
- Simplify recursive MIME walking.
- Don't buffer big parts in memory (e.g. attachments).
- Stop parsing as soon as a plain-text part is found.

While at it, remove a bunch of unused arguments.