### PR TITLE
Take header in ExtractRecipients

### DIFF
--- a/db/message.go
+++ b/db/message.go
@@ -111,8 +111,7 @@ func BitwiseToFlags(bitwiseFlags int) []imap.Flag {
 	return flags
 }
 
-func ExtractRecipients(msg *message.Entity) []Recipient {
-	header := msg.Header
+func ExtractRecipients(header message.Header) []Recipient {
 	recipients := make([]Recipient, 0)
 	uniquePairs := make(map[string]struct{})
 

--- a/server/imap/append.go
+++ b/server/imap/append.go
@@ -127,7 +127,7 @@ func (s *IMAPSession) appendSingle(ctx context.Context, mbox *db.Mailbox, messag
 	}
 
 	// log.Println("Plaintext body:", *plaintextBody)
-	recipients := db.ExtractRecipients(messageContent)
+	recipients := db.ExtractRecipients(messageContent.Header)
 	// Generate a new UUID for the message
 	uuidKey := uuid.New()
 

--- a/server/lmtp/session.go
+++ b/server/lmtp/session.go
@@ -107,7 +107,7 @@ func (s *LMTPSession) Data(r io.Reader) error {
 		}
 	}
 
-	recipients := db.ExtractRecipients(messageContent)
+	recipients := db.ExtractRecipients(messageContent.Header)
 	uuidKey := uuid.New()
 
 	// TODO: SIEVE filtering


### PR DESCRIPTION
A message.Entity must only be read once. Make it clearer that the function only looks at the message header without consuming the body by changing the type of the argument.