### PR TITLE
db: pick a fixed UIDVALIDITY

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -58,11 +58,6 @@ type MailboxPoll struct {
 	ModSeq      uint64
 }
 
-// generateUidValidity generates a unique UIDVALIDITY value based on the current time in nanoseconds
-func generateUIDValidity() uint32 {
-	return uint32(time.Now().Unix()) // Unix timestamp in seconds, which fits in uint32
-}
-
 // NewDatabase initializes a new SQL database connection
 func NewDatabase(ctx context.Context, host, port, user, password, dbname string) (*Database, error) {
 	// Construct the connection string

--- a/db/mailbox.go
+++ b/db/mailbox.go
@@ -155,13 +155,11 @@ func (db *Database) GetMailboxByName(ctx context.Context, userID int, name strin
 }
 
 func (db *Database) CreateMailbox(ctx context.Context, userID int, name string, parentID *int) error {
-	uidValidity := generateUIDValidity()
-
 	// Try to insert the mailbox into the database
 	_, err := db.Pool.Exec(ctx, `
-        INSERT INTO mailboxes (user_id, name, parent_id, uid_validity, subscribed) 
-        VALUES ($1, $2, $3, $4, $5)
-    `, userID, name, parentID, uidValidity, true)
+		INSERT INTO mailboxes (user_id, name, parent_id, uid_validity, subscribed)
+		VALUES ($1, $2, $3, $4, $5)
+	`, userID, name, parentID, 1, true)
 
 	// Handle errors, including unique constraint and foreign key violations
 	if err != nil {


### PR DESCRIPTION
No need to generate a random one. With a fixed one, we can bump the value more easily when needed.