### PR TITLE
db: fix SetMessageFlags with zero custom flags

### DIFF
--- a/db/flags.go
+++ b/db/flags.go
@@ -41,6 +41,11 @@ func SplitFlags(flags []imap.Flag) (systemFlags []imap.Flag, customKeywords []st
 	slices.Sort(customKeywords)
 	// Compact removes adjacent duplicates, resulting in a sorted slice of unique keywords.
 	customKeywords = slices.Compact(customKeywords)
+	if len(customKeywords) == 0 {
+		// json.Marshal encodes nil lists as null instead of an empty array,
+		// avoid this by allocating a zero-length slice
+		customKeywords = []string{}
+	}
 	return
 }
 


### PR DESCRIPTION
This failed with an SQL error, because the new flags were set to null and this made the constraint max_custom_flags_check error out. Indeed, jsonb_array_length expects an array instead of null.

Fixes 50 test cases in imaptest.