### PR TITLE
feat: purge accounts via admin API

### DIFF
--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -246,6 +246,38 @@ curl -X DELETE http://localhost:8080/admin/accounts/user@example.com \
   -H "Authorization: Bearer your-api-key"
 ```
 
+#### Delete Account (Purge)
+
+**Endpoint:** `DELETE /admin/accounts/{email}?purge=true`
+
+Permanently delete an account and all of its data — messages, S3 objects, mailboxes and credentials — with no grace period. This is irreversible: the account cannot be recovered with `/restore`. Equivalent to `sora-admin accounts delete --email <email> --confirm --purge`.
+
+The account does not need to be soft-deleted first. Purging a large mailbox can take a while, since every S3 object is deleted in batches; keep the client timeout generous.
+
+**Response:** `200 OK`
+```json
+{
+  "email": "user@example.com",
+  "messages_expunged": 1420,
+  "s3_objects_deleted": 1418,
+  "messages_deleted": 1420,
+  "message": "Account purged successfully. All data (messages, mailboxes, credentials) has been permanently deleted."
+}
+```
+
+Like the CLI, this does not terminate the account's active sessions. Use `POST /admin/connections/kick` (or `sora-admin connections kick --user <email>`) if you need existing connections dropped.
+
+**Errors:**
+- `404 Not Found` — no account with that address
+- `503 Service Unavailable` — the server has no object storage configured, so S3 data cannot be removed
+- `500 Internal Server Error` — purge failed partway; data may be partially deleted. The operation is resumable, so retrying continues where it stopped.
+
+**Example:**
+```bash
+curl -X DELETE "http://localhost:8080/admin/accounts/user@example.com?purge=true" \
+  -H "Authorization: Bearer your-api-key"
+```
+
 #### Restore Deleted Account
 
 **Endpoint:** `POST /admin/accounts/{email}/restore`

--- a/integration_tests/adminapi/purge_test.go
+++ b/integration_tests/adminapi/purge_test.go
@@ -1,0 +1,209 @@
+//go:build integration
+
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/migadu/sora/cache"
+	"github.com/migadu/sora/integration_tests/common"
+	"github.com/migadu/sora/server/adminapi"
+	"github.com/migadu/sora/storage"
+)
+
+// setupHTTPAPIServerForPurge is like setupHTTPAPIServer but wires object
+// storage, which the default harness leaves nil — without it the purge endpoint
+// reports 503 because it cannot remove S3 data. Pass nil to exercise that case.
+//
+// The storage handle is never called by these tests: the accounts they purge
+// have no uploaded messages, so the purge finds no S3 objects to delete.
+func setupHTTPAPIServerForPurge(t *testing.T, s3 *storage.S3Storage) *HTTPAPITestServer {
+	t.Helper()
+
+	rdb := common.SetupTestDatabase(t)
+
+	cacheDir := t.TempDir()
+	sourceDB := &testSourceDB{rdb: rdb}
+	testCache, err := cache.New(cacheDir, 100*1024*1024, 10*1024*1024, 5*time.Minute, 1*time.Hour, sourceDB)
+	if err != nil {
+		t.Fatalf("Failed to create test cache: %v", err)
+	}
+
+	addr := common.GetRandomAddress(t)
+	options := adminapi.ServerOptions{
+		Addr:         addr,
+		APIKey:       testAPIKey,
+		AllowedHosts: []string{},
+		Cache:        testCache,
+		Storage:      s3,
+		TLS:          false,
+	}
+
+	server, err := adminapi.New(rdb, options)
+	if err != nil {
+		t.Fatalf("Failed to create HTTP API server: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errChan := make(chan error, 1)
+	go adminapi.Start(ctx, rdb, options, errChan)
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case err := <-errChan:
+		cancel()
+		t.Fatalf("Failed to start HTTP API server: %v", err)
+	default:
+	}
+
+	return &HTTPAPITestServer{
+		URL:     fmt.Sprintf("http://%s", addr),
+		server:  server,
+		rdb:     rdb,
+		cache:   testCache,
+		cleanup: func() { cancel(); testCache.Close() },
+	}
+}
+
+// createPurgeAccount creates an account with an INBOX so the purge has a
+// mailbox to remove, and returns the account ID.
+func createPurgeAccount(t *testing.T, server *HTTPAPITestServer, email string) int64 {
+	t.Helper()
+	ctx := context.Background()
+
+	resp, body := server.makeRequest(t, "POST", "/admin/accounts", map[string]string{
+		"email": email, "password": "testpassword123",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create account %s: %d %s", email, resp.StatusCode, string(body))
+	}
+
+	var accountID int64
+	if err := server.rdb.GetDatabase().GetReadPool().QueryRow(ctx,
+		"SELECT account_id FROM credentials WHERE address = $1", email).Scan(&accountID); err != nil {
+		t.Fatalf("get account ID: %v", err)
+	}
+
+	if _, err := server.rdb.GetDatabase().GetWritePool().Exec(ctx,
+		"INSERT INTO mailboxes (account_id, name, uid_validity, path) VALUES ($1, $2, extract(epoch from now())::bigint, $3)",
+		accountID, "INBOX", "INBOX"); err != nil {
+		t.Fatalf("create INBOX: %v", err)
+	}
+
+	return accountID
+}
+
+// TestAdminAPI_PurgeAccount verifies that DELETE /admin/accounts/{email}?purge=true
+// removes the account for good: it is no longer visible through the API and
+// cannot be restored.
+func TestAdminAPI_PurgeAccount(t *testing.T) {
+	server := setupHTTPAPIServerForPurge(t, &storage.S3Storage{})
+	defer server.Close()
+
+	email := fmt.Sprintf("purge-%d@example.com", time.Now().UnixNano())
+	createPurgeAccount(t, server, email)
+
+	resp, body := server.makeRequest(t, "DELETE", "/admin/accounts/"+email+"?purge=true", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("purge: %d %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]any
+	server.expectJSON(t, body, &result)
+	if result["email"] != email {
+		t.Errorf("expected email %q in response, got %v", email, result["email"])
+	}
+	if message, _ := result["message"].(string); !strings.Contains(message, "purged successfully") {
+		t.Errorf("expected purge confirmation, got %v", result["message"])
+	}
+
+	t.Run("account no longer exists", func(t *testing.T) {
+		resp, body := server.makeRequest(t, "GET", "/admin/accounts/"+email+"/exists", nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("exists check: %d %s", resp.StatusCode, string(body))
+		}
+		var existsResult map[string]any
+		server.expectJSON(t, body, &existsResult)
+		if exists, _ := existsResult["exists"].(bool); exists {
+			t.Errorf("expected account to not exist after purge, got %v", existsResult)
+		}
+	})
+
+	t.Run("account cannot be fetched", func(t *testing.T) {
+		resp, _ := server.makeRequest(t, "GET", "/admin/accounts/"+email, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected 404 fetching a purged account, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("purged account cannot be restored", func(t *testing.T) {
+		resp, _ := server.makeRequest(t, "POST", "/admin/accounts/"+email+"/restore", nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected 404 restoring a purged account, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestAdminAPI_DeleteAccount_WithoutPurge guards the default: no purge parameter
+// still means a soft delete that honours the grace period and can be restored.
+func TestAdminAPI_DeleteAccount_WithoutPurge(t *testing.T) {
+	server := setupHTTPAPIServerForPurge(t, &storage.S3Storage{})
+	defer server.Close()
+
+	email := fmt.Sprintf("purge-soft-%d@example.com", time.Now().UnixNano())
+	createPurgeAccount(t, server, email)
+
+	resp, body := server.makeRequest(t, "DELETE", "/admin/accounts/"+email, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("soft delete: %d %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]any
+	server.expectJSON(t, body, &result)
+	if message, _ := result["message"].(string); !strings.Contains(message, "grace period") {
+		t.Errorf("expected soft-delete message, got %v", result["message"])
+	}
+
+	resp, body = server.makeRequest(t, "POST", "/admin/accounts/"+email+"/restore", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("restore soft-deleted account: %d %s", resp.StatusCode, string(body))
+	}
+}
+
+// TestAdminAPI_PurgeAccount_Errors covers the failure paths of the purge parameter.
+func TestAdminAPI_PurgeAccount_Errors(t *testing.T) {
+	t.Run("unknown account", func(t *testing.T) {
+		server := setupHTTPAPIServerForPurge(t, &storage.S3Storage{})
+		defer server.Close()
+
+		email := fmt.Sprintf("purge-missing-%d@example.com", time.Now().UnixNano())
+		resp, _ := server.makeRequest(t, "DELETE", "/admin/accounts/"+email+"?purge=true", nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected 404 purging an unknown account, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("no storage configured", func(t *testing.T) {
+		server := setupHTTPAPIServerForPurge(t, nil)
+		defer server.Close()
+
+		email := fmt.Sprintf("purge-nostorage-%d@example.com", time.Now().UnixNano())
+		createPurgeAccount(t, server, email)
+
+		resp, body := server.makeRequest(t, "DELETE", "/admin/accounts/"+email+"?purge=true", nil)
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503 when storage is unconfigured, got %d %s", resp.StatusCode, string(body))
+		}
+		server.expectError(t, body, "no object storage configured")
+
+		// A refused purge must leave the account untouched.
+		resp, body = server.makeRequest(t, "GET", "/admin/accounts/"+email, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected account to survive a refused purge, got %d %s", resp.StatusCode, string(body))
+		}
+	})
+}

--- a/server/adminapi/purge.go
+++ b/server/adminapi/purge.go
@@ -1,0 +1,160 @@
+package adminapi
+
+// purge.go - Immediate, irreversible account deletion for the admin API.
+//
+// This is the HTTP counterpart of `sora-admin accounts delete --purge`. It
+// deliberately keeps its own copy of the expunge-then-cleanup sequence rather
+// than sharing one with the CLI: the CLI reports progress to a terminal and
+// builds its own S3 client from a config file, while here everything goes to
+// the server log and reuses the server's storage. If the deletion sequence
+// changes in one place, review the other.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/migadu/sora/consts"
+	"github.com/migadu/sora/db"
+	"github.com/migadu/sora/helpers"
+	"github.com/migadu/sora/logger"
+)
+
+// purgeBatchSize is how many uploaded objects are fetched and deleted per round.
+const purgeBatchSize = 1000
+
+// purgeAccount permanently deletes an account and all of its data (messages,
+// S3 objects, mailboxes, credentials) with no grace period. It is irreversible
+// and cannot be undone with /restore.
+func (s *Server) purgeAccount(ctx context.Context, w http.ResponseWriter, email string) {
+	if s.storage == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Purge unavailable: no object storage configured")
+		return
+	}
+
+	accountID, err := s.rdb.GetAccountIDByEmailWithRetry(ctx, email)
+	if err != nil {
+		if errors.Is(err, consts.ErrUserNotFound) {
+			s.writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		logger.Warn("HTTP API: Error looking up account for purge", "name", s.name, "email", email, "error", err)
+		s.writeError(w, http.StatusInternalServerError, "Error purging account")
+		return
+	}
+
+	// Detach from the request: a purge is destructive and can outlive both the
+	// server's WriteTimeout and an impatient client. Cancelling it midway would
+	// leave the account half-deleted.
+	ctx = context.WithoutCancel(ctx)
+
+	logger.Info("HTTP API: Purging account", "name", s.name, "email", email, "account_id", accountID)
+
+	stats, err := s.purgeAccountData(ctx, accountID, email)
+	if err != nil {
+		// The purge is resumable: messages are only removed from the database
+		// once their S3 objects are gone, so retrying continues where it stopped.
+		logger.Warn("HTTP API: Error purging account", "name", s.name, "email", email, "account_id", accountID,
+			"s3_objects_deleted", stats.s3Objects, "messages_deleted", stats.messages, "error", err)
+		s.writeError(w, http.StatusInternalServerError, "Error purging account, data may be partially deleted: "+err.Error())
+		return
+	}
+
+	logger.Info("HTTP API: Account purged", "name", s.name, "email", email, "account_id", accountID,
+		"messages_expunged", stats.expunged, "s3_objects_deleted", stats.s3Objects, "messages_deleted", stats.messages)
+
+	s.writeJSON(w, http.StatusOK, map[string]any{
+		"email":              email,
+		"messages_expunged":  stats.expunged,
+		"s3_objects_deleted": stats.s3Objects,
+		"messages_deleted":   stats.messages,
+		"message":            "Account purged successfully. All data (messages, mailboxes, credentials) has been permanently deleted.",
+	})
+}
+
+// purgeStats records what a purge removed, including on the error path so a
+// partial purge can be reported.
+type purgeStats struct {
+	expunged  int64
+	s3Objects int
+	messages  int64
+}
+
+// purgeAccountData deletes every trace of an account. Messages are expunged
+// first so they can safely be deleted, then S3 objects and their database rows
+// go in batches, and finally the mailboxes, credentials and the account itself.
+func (s *Server) purgeAccountData(ctx context.Context, accountID int64, email string) (purgeStats, error) {
+	var stats purgeStats
+
+	// Mark all messages as expunged (atomic, idempotent). Even if this reports 0
+	// because a previous run already did it, we still look for leftover S3 objects.
+	expunged, err := s.rdb.ExpungeAllMessagesForAccount(ctx, accountID)
+	if err != nil {
+		return stats, fmt.Errorf("failed to expunge messages: %w", err)
+	}
+	stats.expunged = expunged
+	logger.Debug("HTTP API: Purge expunged messages", "name", s.name, "email", email, "count", expunged)
+
+	// Delete S3 objects and their rows in batches: fetch -> delete from S3 ->
+	// delete from the database. Rows are only dropped for objects that really
+	// left S3, which is what makes an interrupted purge safe to repeat.
+	for {
+		// GetAllUploadedObjectsForAccount filters on uploaded = TRUE, and each
+		// iteration deletes what it returned, so this acts as pagination.
+		batch, err := s.rdb.GetAllUploadedObjectsForAccount(ctx, accountID, purgeBatchSize)
+		if err != nil {
+			return stats, fmt.Errorf("failed to scan S3 objects: %w", err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		s3Keys := make([]string, 0, len(batch))
+		keyToCandidate := make(map[string]db.UserScopedObjectForCleanup, len(batch))
+		for _, candidate := range batch {
+			s3Key := helpers.NewS3Key(candidate.S3Domain, candidate.S3Localpart, candidate.ContentHash)
+			s3Keys = append(s3Keys, s3Key)
+			keyToCandidate[s3Key] = candidate
+		}
+
+		var deletedFromS3 []db.UserScopedObjectForCleanup
+		var failed int
+		for s3Key, deleteErr := range s.storage.DeleteBulk(s3Keys) {
+			logger.Warn("HTTP API: Purge failed to delete S3 object", "name", s.name, "email", email, "key", s3Key, "error", deleteErr)
+			failed++
+			delete(keyToCandidate, s3Key)
+		}
+		for _, candidate := range keyToCandidate {
+			deletedFromS3 = append(deletedFromS3, candidate)
+		}
+		stats.s3Objects += len(deletedFromS3)
+
+		if len(deletedFromS3) == 0 {
+			// Nothing left S3, so the next iteration would fetch the same batch
+			// forever. Stop instead of spinning.
+			return stats, fmt.Errorf("failed to delete any S3 objects in current batch (%d failed)", failed)
+		}
+
+		deleted, err := s.rdb.DeleteExpungedMessagesByS3KeyPartsBatchWithRetry(ctx, deletedFromS3)
+		if err != nil {
+			return stats, fmt.Errorf("failed to delete messages from DB: %w", err)
+		}
+		stats.messages += deleted
+
+		logger.Debug("HTTP API: Purge deleted batch", "name", s.name, "email", email,
+			"s3_objects", len(deletedFromS3), "messages", deleted, "s3_failures", failed)
+	}
+
+	if err := s.rdb.PurgeMailboxesForAccount(ctx, accountID); err != nil {
+		return stats, fmt.Errorf("failed to purge mailboxes: %w", err)
+	}
+	if err := s.rdb.PurgeCredentialsForAccount(ctx, accountID); err != nil {
+		return stats, fmt.Errorf("failed to purge credentials: %w", err)
+	}
+	if err := s.rdb.PurgeAccount(ctx, accountID); err != nil {
+		return stats, fmt.Errorf("failed to purge account: %w", err)
+	}
+
+	return stats, nil
+}

--- a/server/adminapi/server.go
+++ b/server/adminapi/server.go
@@ -898,6 +898,12 @@ func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 	email := extractLastPathSegment(r.URL.Path)
 	ctx := r.Context()
 
+	// ?purge=true skips the grace period and deletes everything immediately
+	if r.URL.Query().Get("purge") == "true" {
+		s.purgeAccount(ctx, w, email)
+		return
+	}
+
 	err := s.rdb.DeleteAccountWithRetry(ctx, email)
 	if err != nil {
 		if errors.Is(err, consts.ErrUserNotFound) {
@@ -1949,7 +1955,7 @@ func (s *Server) handleConfigInfo(w http.ResponseWriter, r *http.Request) {
 				"POST /admin/accounts",
 				"GET /admin/accounts/{email}",
 				"PUT /admin/accounts/{email}",
-				"DELETE /admin/accounts/{email}",
+				"DELETE /admin/accounts/{email} (soft delete, ?purge=true to delete permanently)",
 				"POST /admin/accounts/{email}/restore",
 				"GET /admin/accounts/{email}/exists",
 				"POST /admin/accounts/{email}/credentials",


### PR DESCRIPTION
- Deletes the account without the grace period. 
-  This is the HTTP counterpart of `sora-admin accounts delete --purge`

Rationale behind this is that we need an endpoint in our web-app, where we can delete whole account:

Potentianl use-case:

- User creates mailbox (sora accounts)
- Then decides to delete it, now in sora we have account which is soft-deleted
- Then creates identity (sora credential) under the same address as previously created mailbox 
- Credential cannot be created on sora

@dejanstrbac Please let me know what do you think about this. 