### PR TITLE
fix: accept non-synchronizing literals ({N+}) in IMAP proxy LOGIN

### DIFF
--- a/integration_tests/imapproxy/literal_login_test.go
+++ b/integration_tests/imapproxy/literal_login_test.go
@@ -257,6 +257,100 @@ func TestIMAPProxyLiteralLoginEdgeCases(t *testing.T) {
 	}
 }
 
+// TestIMAPProxyNonSyncLiteralLogin tests LOGIN with non-synchronizing literals
+// ({size+}, RFC 7888 LITERAL+), which are base functionality in IMAP4rev2
+// (RFC 9051 §4.3) — the proxy advertises IMAP4rev2, so rev2 clients (e.g. the
+// August 2026 "new Outlook" rollout) send these without waiting for a
+// continuation. The whole command arrives in a single write; the proxy must
+// not send "+ " and must not misparse the literal data as commands.
+func TestIMAPProxyNonSyncLiteralLogin(t *testing.T) {
+	common.SkipIfDatabaseUnavailable(t)
+
+	backendServer, account := common.SetupIMAPServerWithPROXY(t)
+	defer backendServer.Close()
+
+	proxyAddress := common.GetRandomAddress(t)
+	proxy := setupIMAPProxyWithPROXY(t, backendServer.ResilientDB, proxyAddress, []string{backendServer.Address})
+	defer proxy.Close()
+
+	time.Sleep(300 * time.Millisecond)
+
+	email := account.Email
+	password := account.Password
+
+	testCases := []struct {
+		name    string
+		payload string
+	}{
+		{
+			// The new-Outlook shape: everything in one write, no waiting.
+			name: "both_nonsync_single_write",
+			payload: fmt.Sprintf("A001 LOGIN {%d+}\r\n%s {%d+}\r\n%s\r\n",
+				len(email), email, len(password), password),
+		},
+		{
+			name: "username_nonsync_password_quoted",
+			payload: fmt.Sprintf("A001 LOGIN {%d+}\r\n%s \"%s\"\r\n",
+				len(email), email, escapeForIMAP(password)),
+		},
+		{
+			name: "username_quoted_password_nonsync",
+			payload: fmt.Sprintf("A001 LOGIN \"%s\" {%d+}\r\n%s\r\n",
+				email, len(password), password),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := net.Dial("tcp", proxyAddress)
+			if err != nil {
+				t.Fatalf("Failed to connect: %v", err)
+			}
+			defer conn.Close()
+			conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+			reader := bufio.NewReader(conn)
+			greeting, err := reader.ReadString('\n')
+			if err != nil {
+				t.Fatalf("Failed to read greeting: %v", err)
+			}
+			if !strings.HasPrefix(greeting, "* OK") {
+				t.Fatalf("Invalid greeting: %s", greeting)
+			}
+
+			// Send the entire command at once — a non-sync literal client
+			// does not wait for continuations.
+			if _, err := conn.Write([]byte(tc.payload)); err != nil {
+				t.Fatalf("Failed to send LOGIN: %v", err)
+			}
+
+			var responses []string
+			for {
+				line, err := reader.ReadString('\n')
+				if err != nil {
+					t.Fatalf("Failed to read response (got so far: %v): %v", responses, err)
+				}
+				responses = append(responses, line)
+				if strings.HasPrefix(line, "+") {
+					t.Errorf("Server sent continuation for non-synchronizing literal: %s", strings.TrimSpace(line))
+				}
+				if strings.HasPrefix(line, "A001 ") {
+					break
+				}
+				if len(responses) > 10 {
+					t.Fatalf("Too many response lines: %v", responses)
+				}
+			}
+
+			final := responses[len(responses)-1]
+			if !strings.Contains(final, "A001 OK") {
+				t.Fatalf("Non-sync literal login failed: %s (all: %v)", strings.TrimSpace(final), responses)
+			}
+			t.Logf("✓ Non-sync literal login succeeded: %s", strings.TrimSpace(final))
+		})
+	}
+}
+
 // escapeForIMAP escapes special characters for IMAP quoted strings per RFC 3501.
 // Backslashes and double-quotes must be escaped.
 func escapeForIMAP(s string) string {

--- a/server/command_parser.go
+++ b/server/command_parser.go
@@ -127,21 +127,35 @@ func UnquoteString(str string) string {
 	return result.String()
 }
 
-// ParseLiteral parses an IMAP literal string {size} and returns the size.
+// ParseLiteral parses an IMAP literal string {size} or {size+} and returns
+// the size plus whether the literal is non-synchronizing. Non-synchronizing
+// literals ({size+}, RFC 7888 LITERAL+) are base functionality in IMAP4rev2
+// (RFC 9051 §4.3): the client sends the literal data immediately without
+// waiting for a continuation response, so callers must NOT send one.
 // Returns error if the format is invalid or size is negative.
-func ParseLiteral(str string) (int, error) {
+func ParseLiteral(str string) (size int, nonSync bool, err error) {
 	if !strings.HasPrefix(str, "{") || !strings.HasSuffix(str, "}") {
-		return 0, fmt.Errorf("not a literal")
+		return 0, false, fmt.Errorf("not a literal")
 	}
 
 	sizeStr := str[1 : len(str)-1]
-	size, err := strconv.Atoi(sizeStr)
-	if err != nil {
-		return 0, fmt.Errorf("invalid literal size: %w", err)
+	if strings.HasSuffix(sizeStr, "+") {
+		nonSync = true
+		sizeStr = sizeStr[:len(sizeStr)-1]
 	}
-	if size < 0 {
-		return 0, fmt.Errorf("negative literal size")
+	// RFC grammar allows digits only (Atoi would also accept a leading sign)
+	if sizeStr == "" {
+		return 0, false, fmt.Errorf("empty literal size")
+	}
+	for _, c := range sizeStr {
+		if c < '0' || c > '9' {
+			return 0, false, fmt.Errorf("invalid literal size: %q", sizeStr)
+		}
+	}
+	size, err = strconv.Atoi(sizeStr)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid literal size: %w", err)
 	}
 
-	return size, nil
+	return size, nonSync, nil
 }

--- a/server/command_parser_test.go
+++ b/server/command_parser_test.go
@@ -375,10 +375,11 @@ func TestParseLineUnquoteStringIntegration(t *testing.T) {
 
 func TestParseLiteral(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    int
-		wantErr bool
+		name        string
+		input       string
+		want        int
+		wantNonSync bool
+		wantErr     bool
 	}{
 		{
 			name:    "valid literal",
@@ -397,6 +398,38 @@ func TestParseLiteral(t *testing.T) {
 			input:   "{12345}",
 			want:    12345,
 			wantErr: false,
+		},
+		{
+			name:        "non-synchronizing literal (LITERAL+/IMAP4rev2)",
+			input:       "{10+}",
+			want:        10,
+			wantNonSync: true,
+			wantErr:     false,
+		},
+		{
+			name:        "non-synchronizing literal zero",
+			input:       "{0+}",
+			want:        0,
+			wantNonSync: true,
+			wantErr:     false,
+		},
+		{
+			name:    "invalid - plus only",
+			input:   "{+}",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid - double plus",
+			input:   "{10++}",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid - plus before size",
+			input:   "{+10}",
+			want:    0,
+			wantErr: true,
 		},
 		{
 			name:    "invalid - no braces",
@@ -438,13 +471,16 @@ func TestParseLiteral(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseLiteral(tt.input)
+			got, nonSync, err := ParseLiteral(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseLiteral() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
 				t.Errorf("ParseLiteral() = %v, want %v", got, tt.want)
+			}
+			if nonSync != tt.wantNonSync {
+				t.Errorf("ParseLiteral() nonSync = %v, want %v", nonSync, tt.wantNonSync)
 			}
 		})
 	}

--- a/server/imapproxy/session.go
+++ b/server/imapproxy/session.go
@@ -211,7 +211,7 @@ func (s *Session) handleConnection() {
 
 				// Check if username is a literal
 				if strings.HasPrefix(args[0], "{") && strings.HasSuffix(args[0], "}") {
-					literalSize, err := server.ParseLiteral(args[0])
+					literalSize, nonSync, err := server.ParseLiteral(args[0])
 					if err != nil || literalSize > 8192 {
 						if s.handleAuthError(fmt.Sprintf("%s BAD Invalid literal in username", tag)) {
 							return
@@ -219,8 +219,11 @@ func (s *Session) handleConnection() {
 						continue
 					}
 
-					// Send continuation (RFC 9051: continue-req = "+" SP ...)
-					s.sendResponse("+ ")
+					// Send continuation (RFC 9051: continue-req = "+" SP ...) only for
+					// synchronizing literals; for {N+} the data is already in flight.
+					if !nonSync {
+						s.sendResponse("+ ")
+					}
 
 					// Read literal data
 					literalBuf := make([]byte, literalSize)
@@ -252,7 +255,7 @@ func (s *Session) handleConnection() {
 
 					// Check if password is a literal
 					if strings.HasPrefix(line, "{") && strings.HasSuffix(line, "}") {
-						literalSize, err := server.ParseLiteral(line)
+						literalSize, nonSync, err := server.ParseLiteral(line)
 						if err != nil || literalSize > 8192 {
 							if s.handleAuthError(fmt.Sprintf("%s BAD Invalid literal in password", tag)) {
 								return
@@ -260,8 +263,11 @@ func (s *Session) handleConnection() {
 							continue
 						}
 
-						// Send continuation (RFC 9051: continue-req = "+" SP ...)
-						s.sendResponse("+ ")
+						// Send continuation (RFC 9051: continue-req = "+" SP ...) only for
+						// synchronizing literals; for {N+} the data is already in flight.
+						if !nonSync {
+							s.sendResponse("+ ")
+						}
 
 						// Read literal data
 						literalBuf := make([]byte, literalSize)
@@ -286,7 +292,7 @@ func (s *Session) handleConnection() {
 
 					// Check if password is a literal (username was not)
 					if strings.HasPrefix(args[1], "{") && strings.HasSuffix(args[1], "}") {
-						literalSize, err := server.ParseLiteral(args[1])
+						literalSize, nonSync, err := server.ParseLiteral(args[1])
 						if err != nil || literalSize > 8192 {
 							if s.handleAuthError(fmt.Sprintf("%s BAD Invalid literal in password", tag)) {
 								return
@@ -294,8 +300,11 @@ func (s *Session) handleConnection() {
 							continue
 						}
 
-						// Send continuation (RFC 9051: continue-req = "+" SP ...)
-						s.sendResponse("+ ")
+						// Send continuation (RFC 9051: continue-req = "+" SP ...) only for
+						// synchronizing literals; for {N+} the data is already in flight.
+						if !nonSync {
+							s.sendResponse("+ ")
+						}
 
 						// Read literal data
 						literalBuf := make([]byte, literalSize)


### PR DESCRIPTION
## Problem

The August 2026 "new Outlook" (web) rollout broke IMAP login for all users behind the sora proxies, surfacing in Outlook as `INVALIDCREDENTIALS INTERACTIONREQUIRED`.

The proxy greeting advertises `IMAP4rev2`. RFC 9051 §4.3 makes non-synchronizing literals (`{N+}`, RFC 7888 LITERAL+) **base rev2 functionality** — a rev2 client may send the whole command in one write without waiting for continuations:

```
A1 LOGIN {29+}
user@example.com {9+}
secretpwd
```

`server.ParseLiteral` passed the braced size straight to `strconv.Atoi`, so `{29+}` failed to parse. The session then derailed:

```
A1 BAD Invalid literal in username
user@example.com... NO Command not supported before authentication   ← literal data misparsed as commands
* BYE Too many invalid commands
```

Reproduced verbatim against production. Only the proxy's hand-rolled pre-auth loop is affected — backends use go-imap, which advertises and parses `{N+}` correctly. No other mainstream client sends non-sync literals to the proxy (quoted strings / `AUTHENTICATE PLAIN`), which is why only new Outlook broke.

## Fix

- `ParseLiteral` returns `(size, nonSync, err)`, accepts `{N+}`, and is digit-strict (rejects `{+10}`, `{10++}` — `Atoi` would accept a leading sign)
- the three LOGIN literal sites in `server/imapproxy/session.go` send the `+ ` continuation only for synchronizing literals; for `{N+}` the data is already in flight

## Tests

- `TestParseLiteral`: non-sync and malformed-size cases added
- `TestIMAPProxyNonSyncLiteralLogin` (integration): the exact single-write Outlook shape, plus mixed literal/quoted variants, asserting login succeeds and **no spurious continuation** is sent
- Red/green verified: with the old parser behavior the new test fails with `A001 BAD Invalid literal in username` (identical to the production failure); with the fix it passes. Existing sync-literal tests unaffected.
