### PR TITLE
fix: honest pre-auth capability list in IMAP proxy greeting

### DIFF
--- a/integration_tests/imapproxy/greeting_caps_test.go
+++ b/integration_tests/imapproxy/greeting_caps_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+package imapproxy_test
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/migadu/sora/integration_tests/common"
+	"github.com/migadu/sora/server/imapproxy"
+)
+
+// TestIMAPProxyGreetingCapabilities pins the pre-auth capability list the
+// proxy advertises and checks that every token is a promise the pre-auth
+// loop actually keeps. It exists because the greeting once carried a bare
+// "LOGIN" token — not a capability at all, and read as a SASL mechanism it
+// advertised something AUTHENTICATE refused — and omitted SASL-IR/LITERAL-
+// even though both were accepted. The greeting and the CAPABILITY response
+// are built from one constant; this test guards the constant.
+func TestIMAPProxyGreetingCapabilities(t *testing.T) {
+	common.SkipIfDatabaseUnavailable(t)
+
+	backendServer, account := common.SetupIMAPServerWithPROXY(t)
+	defer backendServer.Close()
+
+	proxyAddress := common.GetRandomAddress(t)
+	proxy := setupIMAPProxyWithPROXY(t, backendServer.ResilientDB, proxyAddress, []string{backendServer.Address})
+	defer proxy.Close()
+
+	time.Sleep(300 * time.Millisecond)
+
+	dial := func(t *testing.T) (net.Conn, *bufio.Reader, string) {
+		t.Helper()
+		conn, err := net.Dial("tcp", proxyAddress)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		conn.SetDeadline(time.Now().Add(10 * time.Second))
+		reader := bufio.NewReader(conn)
+		greeting, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("greeting: %v", err)
+		}
+		return conn, reader, strings.TrimSpace(greeting)
+	}
+
+	// capsFromBracket extracts the token list from "* OK [CAPABILITY ...] text".
+	capsFromBracket := func(t *testing.T, line string) []string {
+		t.Helper()
+		start := strings.Index(line, "[CAPABILITY ")
+		end := strings.Index(line, "]")
+		if start < 0 || end < start {
+			t.Fatalf("no CAPABILITY response code in greeting: %q", line)
+		}
+		return strings.Fields(line[start+len("[CAPABILITY ") : end])
+	}
+
+	t.Run("exact_token_list", func(t *testing.T) {
+		conn, _, greeting := dial(t)
+		defer conn.Close()
+
+		want := strings.Fields(imapproxy.PreAuthCapabilities)
+		got := capsFromBracket(t, greeting)
+		// The proxy may append configured extra caps (additionalCapsSuffix);
+		// the pinned list must be an exact prefix.
+		if len(got) < len(want) || strings.Join(got[:len(want)], " ") != strings.Join(want, " ") {
+			t.Fatalf("greeting caps = %v, want prefix %v", got, want)
+		}
+
+		// Pin the exact expected surface so any change is a conscious edit here.
+		const pinned = "IMAP4rev2 IMAP4rev1 SASL-IR LITERAL- AUTH=PLAIN"
+		if imapproxy.PreAuthCapabilities != pinned {
+			t.Fatalf("PreAuthCapabilities = %q, want %q (update this test deliberately)", imapproxy.PreAuthCapabilities, pinned)
+		}
+
+		for _, c := range got {
+			if c == "LOGIN" {
+				t.Fatal("bare LOGIN token must not be advertised (not a capability; RFC 3501 uses LOGINDISABLED for the inverse)")
+			}
+			if c == "LITERAL+" {
+				t.Fatal("LITERAL+ must not be advertised: pre-auth literals are bounded, LITERAL- is the honest promise")
+			}
+		}
+	})
+
+	t.Run("capability_response_matches_greeting", func(t *testing.T) {
+		conn, reader, greeting := dial(t)
+		defer conn.Close()
+
+		conn.Write([]byte("A1 CAPABILITY\r\n"))
+		var capLine string
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "* CAPABILITY ") {
+				capLine = strings.TrimPrefix(line, "* CAPABILITY ")
+			}
+			if strings.HasPrefix(line, "A1 ") {
+				break
+			}
+		}
+		if capLine == "" {
+			t.Fatal("no untagged CAPABILITY response")
+		}
+		if got, want := capLine, strings.Join(capsFromBracket(t, greeting), " "); got != want {
+			t.Fatalf("CAPABILITY response %q != greeting caps %q", got, want)
+		}
+	})
+
+	t.Run("every_advertised_auth_mechanism_is_accepted", func(t *testing.T) {
+		conn, _, greeting := dial(t)
+		conn.Close()
+
+		for _, c := range capsFromBracket(t, greeting) {
+			if !strings.HasPrefix(c, "AUTH=") {
+				continue
+			}
+			mech := strings.TrimPrefix(c, "AUTH=")
+			t.Run(mech, func(t *testing.T) {
+				conn, reader, _ := dial(t)
+				defer conn.Close()
+				// Wrong password on purpose: we only care that the mechanism is
+				// dispatched (NO Authentication failed) rather than rejected as
+				// unsupported.
+				ir := base64.StdEncoding.EncodeToString([]byte("\x00" + account.Email + "\x00wrong-password"))
+				conn.Write([]byte(fmt.Sprintf("A1 AUTHENTICATE %s %s\r\n", mech, ir)))
+				line, err := reader.ReadString('\n')
+				if err != nil {
+					t.Fatalf("read: %v", err)
+				}
+				if strings.Contains(line, "only supported mechanism") || strings.Contains(strings.ToUpper(line), "BAD") {
+					t.Fatalf("advertised AUTH=%s but AUTHENTICATE %s was refused: %q", mech, mech, strings.TrimSpace(line))
+				}
+			})
+		}
+	})
+
+	t.Run("sasl_ir_is_honored", func(t *testing.T) {
+		// SASL-IR advertised => AUTHENTICATE PLAIN <initial-response> must work
+		// in one round trip, with no "+" continuation.
+		conn, reader, _ := dial(t)
+		defer conn.Close()
+
+		ir := base64.StdEncoding.EncodeToString([]byte("\x00" + account.Email + "\x00" + account.Password))
+		conn.Write([]byte(fmt.Sprintf("A1 AUTHENTICATE PLAIN %s\r\n", ir)))
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if strings.HasPrefix(line, "+") {
+				t.Fatal("SASL-IR advertised but proxy sent a continuation for an initial response")
+			}
+			if strings.HasPrefix(line, "A1 ") {
+				if !strings.HasPrefix(line, "A1 OK") {
+					t.Fatalf("SASL-IR AUTHENTICATE PLAIN failed: %s", strings.TrimSpace(line))
+				}
+				break
+			}
+		}
+	})
+
+	t.Run("literal_minus_is_honored", func(t *testing.T) {
+		// LITERAL- advertised => a non-synchronizing literal <= 4096 bytes is
+		// accepted with no continuation. Exercised via LOGIN.
+		conn, reader, _ := dial(t)
+		defer conn.Close()
+
+		payload := fmt.Sprintf("A1 LOGIN {%d+}\r\n%s {%d+}\r\n%s\r\n",
+			len(account.Email), account.Email, len(account.Password), account.Password)
+		conn.Write([]byte(payload))
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if strings.HasPrefix(line, "+") {
+				t.Fatal("LITERAL- advertised but proxy sent a continuation for a {N+} literal")
+			}
+			if strings.HasPrefix(line, "A1 ") {
+				if !strings.HasPrefix(line, "A1 OK") {
+					t.Fatalf("non-sync literal LOGIN failed: %s", strings.TrimSpace(line))
+				}
+				break
+			}
+		}
+	})
+}

--- a/server/imapproxy/session.go
+++ b/server/imapproxy/session.go
@@ -497,7 +497,7 @@ func (s *Session) handleConnection() {
 			return
 
 		case "CAPABILITY":
-			s.sendResponse("* CAPABILITY IMAP4rev2 IMAP4rev1 AUTH=PLAIN LOGIN" + s.server.additionalCapsSuffix)
+			s.sendResponse("* CAPABILITY " + PreAuthCapabilities + s.server.additionalCapsSuffix)
 			s.sendResponse(fmt.Sprintf("%s OK CAPABILITY completed", tag))
 
 		case "ID":
@@ -558,12 +558,37 @@ func (s *Session) handleAuthError(response string) bool {
 	return false
 }
 
+// PreAuthCapabilities is the capability list the proxy advertises before
+// authentication, in the greeting and in response to CAPABILITY. It is the
+// single source of truth for both so they cannot drift.
+//
+// Every token here is a promise the pre-auth loop actually keeps:
+//   - IMAP4rev2/IMAP4rev1: rev2 clients (Outlook) send {N+} literals as
+//     baseline behavior; the pre-auth parser accepts them (LOGIN, ID).
+//   - SASL-IR (RFC 4959): AUTHENTICATE PLAIN <initial-response> is accepted;
+//     advertising it saves compliant clients a round trip.
+//   - LITERAL- (RFC 7888): non-synchronizing literals up to 4096 bytes. The
+//     pre-auth path bounds literals at 8 KiB, so LITERAL+ (any size) would be
+//     a promise it cannot keep — a client streaming a large {N+} literal would
+//     get BAD after the bytes are already in flight and desynchronize.
+//     Credentials and ID values fit comfortably; larger literals fall back to
+//     synchronizing form, which is handled with a continuation.
+//   - AUTH=PLAIN: the only SASL mechanism the proxy accepts. Do NOT list
+//     mechanisms the loop rejects — a bare "LOGIN" token used to sit here; it
+//     is not a capability (RFC 3501 signals LOGIN support by the ABSENCE of
+//     LOGINDISABLED) and read as AUTH=LOGIN it advertised a mechanism that
+//     AUTHENTICATE refused.
+//
+// Post-auth the session is a raw relay and the backend's real capabilities
+// take over. TestIMAPProxyGreetingCapabilities pins this list.
+const PreAuthCapabilities = "IMAP4rev2 IMAP4rev1 SASL-IR LITERAL- AUTH=PLAIN"
+
 // sendGreeting sends the IMAP greeting.
 func (s *Session) sendGreeting() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	greeting := "* OK [CAPABILITY IMAP4rev2 IMAP4rev1 AUTH=PLAIN LOGIN" + s.server.additionalCapsSuffix + "] Proxy Ready\r\n"
+	greeting := "* OK [CAPABILITY " + PreAuthCapabilities + s.server.additionalCapsSuffix + "] Proxy Ready\r\n"
 	_, err := s.clientWriter.WriteString(greeting)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Problem

The proxy greeting and its `CAPABILITY` response were two separate string literals reading `IMAP4rev2 IMAP4rev1 AUTH=PLAIN LOGIN`:

- **Bare `LOGIN` token is not a capability.** RFC 3501 signals LOGIN support by the *absence* of `LOGINDISABLED`. Read as a SASL mechanism the token advertised `AUTH=LOGIN` — which `AUTHENTICATE LOGIN` then refused (`NO AUTHENTICATE PLAIN is the only supported mechanism`, verified on prod). Advertising what you reject.
- **`SASL-IR` and non-sync literals accepted but never advertised** — an extra round trip per login for compliant clients (Thunderbird, Apple Mail, K-9 all use SASL-IR when offered).

## Fix

Both sites now derive from a single `PreAuthCapabilities` constant so they cannot drift:

```
* OK [CAPABILITY IMAP4rev2 IMAP4rev1 SASL-IR LITERAL- AUTH=PLAIN] Proxy Ready
```

**`LITERAL-` not `LITERAL+`, deliberately.** The pre-auth path bounds literals at 8 KiB. `LITERAL+` promises any size — a client streaming a large `{N+}` literal would get `BAD` after the bytes are already in flight and desynchronize. `LITERAL-` (≤4096 bytes) covers every credential and ID value; anything larger falls back to the synchronizing form, which is handled with a continuation. Post-auth the session is a raw relay and the backend advertises its own real caps.

Compatibility: no client keys off the bogus `LOGIN` token (it isn't a real capability), so dropping it changes nothing; adding `SASL-IR`/`LITERAL-` only removes round trips. Every token now advertised is behavior the proxy already had.

## Tests

`TestIMAPProxyGreetingCapabilities` (integration) — the guard that stops a bare `LOGIN` from reappearing:
- exact pinned token set (any change must be a conscious edit of the test)
- `CAPABILITY` response byte-identical to greeting caps
- **every advertised `AUTH=<mech>` is actually dispatched by `AUTHENTICATE`** (not refused as unsupported)
- `SASL-IR` honored: initial-response `AUTHENTICATE PLAIN` succeeds with no continuation
- `LITERAL-` honored: `{N+}` LOGIN succeeds with no continuation

Red/green verified: the old greeting fails the pin; advertising `AUTH=LOGIN` fails the mechanism guard. Full imapproxy integration suite green.

Independent of #78 (different lines; no conflict) — both are follow-ups from the Outlook investigation.